### PR TITLE
config: update URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
-url: "http://boozoholics.github.io"
-baseurl: ""
+baseurl: "https://dritings.no"
 title: "boozoholics"
 members:
   - arcane


### PR DESCRIPTION
We've moved to dritings.no, as well as started enforcing HTTPS, so let's
update the configured URL to reflect both.